### PR TITLE
Rename all file paths to use CommanderPi instead of Commander_Pi

### DIFF
--- a/c_desktop.py
+++ b/c_desktop.py
@@ -2,7 +2,7 @@
 import os 
 import subprocess as sp
 dir_path = os.path.dirname(os.path.realpath(__file__))
-f_content = '[Desktop Entry]\nName=CommanderPi\nComment=System info and overclocking\nExec=/home/pi/Commander_Pi/src/start.sh\nIcon=/home/pi/Commander_Pi/src/logo.png\nCategories=Utility;\nVersion=1.0\nType=Application\nTerminal=false\nStartupNotify=true'
+f_content = '[Desktop Entry]\nName=CommanderPi\nComment=System info and overclocking\nExec=/home/pi/CommanderPi/src/start.sh\nIcon=/home/pi/CommanderPi/src/logo.png\nCategories=Utility;\nVersion=1.0\nType=Application\nTerminal=false\nStartupNotify=true'
 d_dir = "/home/pi/Desktop/test.desktop"
 x_dir = "/usr/share/applications/test.desktop"
 print(d_dir)

--- a/src/gui.py
+++ b/src/gui.py
@@ -199,7 +199,7 @@ class Window:
 		
 		
 
-		loadimg = Image.open("/home/pi/Commander_Pi/src/img.png")
+		loadimg = Image.open("/home/pi/CommanderPi/src/img.png")
 		img = ImageTk.PhotoImage(image=loadimg)
                 
 		img_label = tk.Label ( master, image=img)

--- a/src/start.sh
+++ b/src/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo python3 /home/pi/Commander_Pi/src/main.py > a.txt
+sudo python3 /home/pi/CommanderPi/src/main.py > a.txt
 
 
 

--- a/src/update.py
+++ b/src/update.py
@@ -9,7 +9,7 @@ def delete_old():
 		os.system('rm '+path+'/'+name)
 		print("Deleted "+name)
 def download_git(url, name):
-	filename, headers = urllib.request.urlretrieve(url, filename="/home/pi/Commander_Pi/src/"+name)
+	filename, headers = urllib.request.urlretrieve(url, filename="/home/pi/CommanderPi/src/"+name)
 	print ("download start!")
 	print ("download complete!")
 	print ("download file location: ", filename)


### PR DESCRIPTION
By default, `git clone` will download this to `/home/pi/CommanderPi`.
Unfortunately, all the scripts assume they are located in `/home/pi/Commander_Pi`, and so don't work.

Even the test.desktop file tries to run `/home/pi/Commander_Pi/src/start.sh`, which, obviously, [doesn't work](https://github.com/Jack477/CommanderPi/issues/2). Error is "invalid desktop entry file".

Anyway, this pull request fixes all those problems by correcting the file path.