### PR TITLE
added: auto_check switch to cpi.config ..

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import sys
 import os
+#import cpi_config as cf
 import resources as rs
 import bootloader as btl
 import update as up
@@ -731,6 +732,8 @@ class Window:
 		#d = Info_Window()
 		master.protocol("WM_DELETE_WINDOW", lambda:on_Window_Close(master))
 		th.set_theme(master)
-		up.check_update()
+		if rs.auto_check:        # move this to cf.auto_check
+			up.check_update()
+
 		master.mainloop()
 		

--- a/src/resources.py
+++ b/src/resources.py
@@ -17,17 +17,52 @@ home_path = sys.argv[1]
 
 config = configparser.ConfigParser()
 if os.path.exists(home_path+'/CommanderPi/src/cpi.config'):
-	config.read(home_path+'/CommanderPi/src/cpi.config')
-	print("Exist and read")
+	#config.read(home_path+'/CommanderPi/src/cpi.config')
+	print("Exist: cpi.config")
 else:
 	print("Creating config...")
 	config['DEFAULT'] = {'color_mode': '0',
-	'version': '0.4.2'}
+	'version': '0.4.2'} # what is this version for?
+#	'version': '0.7.2'} # inject into app_version
 	with open(home_path+'/CommanderPi/src/cpi.config', 'w') as configfile:
 		config.write(configfile)
+		print("Create: cpi.config")
+config.read(home_path+'/CommanderPi/src/cpi.config')
+
+### auto update
+auto_check=True
+if 'auto_check' in config['DEFAULT']:
+	if config['DEFAULT']['auto_check']=='false':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='False':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='FALSE':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='no':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='No':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='NO':
+		auto_check=False
+	if config['DEFAULT']['auto_check']=='true':
+		auto_check=True
+	if config['DEFAULT']['auto_check']=='True':
+		auto_check=True
+	if config['DEFAULT']['auto_check']=='TRUE':
+		auto_check=True
+	if config['DEFAULT']['auto_check']=='yes':
+		auto_check=True
+	if config['DEFAULT']['auto_check']=='Yes':
+		auto_check=True
+	if config['DEFAULT']['auto_check']=='YES':
+		auto_check=True
+
+def get_auto_check():
+	return auto_check
 
 ### update stuff
-app_version = "Version 0.7.2\n"
+app_version = "Version 0.7.2\n" # this version number should come from the config
+#app_version = "Version "+config['DEFAULT']['version']+"\n"
 print("Here is app-1 "+app_version[:-1])
 def get_app_version():
 	return app_version


### PR DESCRIPTION
workaround for issue #29 (bug in Python?), modified config startup code, now it _always_ reads from the config, even if its just been created, added #30 notes about `version` and `app_version`, included examples and `import config_cpi as cf` - ie lotsa `if` statements needed to idiot proof text values in config file (for the lack of `switch` statement in Python)